### PR TITLE
Refactored PHPMD rules and improved readability

### DIFF
--- a/src/Project/Common/InstanceResolvingRule.php
+++ b/src/Project/Common/InstanceResolvingRule.php
@@ -29,7 +29,7 @@ class InstanceResolvingRule extends AbstractRule implements ClassAware
     /**
      * @var string
      */
-    protected const INSTANCE_PATTERN = '([\w]+(Repository|EntityManager|QueryContainer|Facade|DependencyProvider|Client|Service)$)';
+    protected const INSTANCE_PATTERN = '/\w+(Repository|EntityManager|QueryContainer|Facade|DependencyProvider|Client|Service)$/';
 
     /**
      * @param \PHPMD\AbstractNode $node
@@ -55,15 +55,21 @@ class InstanceResolvingRule extends AbstractRule implements ClassAware
 
                 $referenceName = trim($reference->getName(), '\\');
 
-                if (preg_match(static::INSTANCE_PATTERN, $referenceName)) {
-                    $message = sprintf(
-                        'Entity `%s` is initialized in method `%s`. %s',
-                        $referenceName,
-                        $methodName,
-                        static::RULE,
-                    );
-                    $this->addViolation($methodNode, [$message]);
+                if (preg_match(static::INSTANCE_PATTERN, $referenceName) !== 1) {
+                    continue;
                 }
+
+                $this->addViolation(
+                    $methodNode,
+                    [
+                        sprintf(
+                            'Entity `%s` is initialized in method `%s`. %s',
+                            $referenceName,
+                            $methodName,
+                            static::RULE,
+                        ),
+                    ],
+                );
             }
         }
     }

--- a/src/Project/Common/LayerAccessRule.php
+++ b/src/Project/Common/LayerAccessRule.php
@@ -185,13 +185,13 @@ class LayerAccessRule extends AbstractRule implements ClassAware
      */
     protected function collectPatterns(ClassNode $class): array
     {
-        $patterns = [];
-        foreach ($this->patterns as [$srcPattern, $targetPattern, $message]) {
-            if (preg_match($srcPattern, $class->getNamespaceName())) {
-                $patterns[] = [$srcPattern, $targetPattern, $message];
+        return array_reduce($this->patterns, function ($collectedPatterns, $pattern) use ($class) {
+            [$srcPattern] = $pattern;
+            if (preg_match($srcPattern, $class->getNamespaceName()) === 1) {
+                $collectedPatterns[] = $pattern;
             }
-        }
 
-        return $patterns;
+            return $collectedPatterns;
+        }, []);
     }
 }

--- a/src/Project/Common/LocatorInDependencyProviderOnlyRule.php
+++ b/src/Project/Common/LocatorInDependencyProviderOnlyRule.php
@@ -43,14 +43,14 @@ class LocatorInDependencyProviderOnlyRule extends AbstractRule implements Method
      */
     public function apply(AbstractNode $node): void
     {
-        if ($this->isClassAllowedToUseLocator($node) === true) {
+        if ($this->isClassAllowedToUseLocator($node)) {
             return;
         }
 
         foreach ($node->findChildrenOfType('MethodPostfix') as $classUsage) {
             $methodName = $classUsage->getNode()->getImage();
 
-            if ($this->isLocator($methodName) === false) {
+            if (!$this->isLocator($methodName)) {
                 continue;
             }
 
@@ -73,11 +73,7 @@ class LocatorInDependencyProviderOnlyRule extends AbstractRule implements Method
      */
     protected function isLocator(string $methodName): bool
     {
-        if (preg_match(static::LOCATOR_METHOD_NAMES, $methodName)) {
-            return true;
-        }
-
-        return false;
+        return preg_match(static::LOCATOR_METHOD_NAMES, $methodName) === 1;
     }
 
     /**
@@ -87,10 +83,6 @@ class LocatorInDependencyProviderOnlyRule extends AbstractRule implements Method
      */
     protected function isClassAllowedToUseLocator(AbstractNode $node): bool
     {
-        if (preg_match(static::CLASSES_ALLOWED_TO_USE_LOCATOR, $node->getParentName())) {
-            return true;
-        }
-
-        return false;
+        return preg_match(static::CLASSES_ALLOWED_TO_USE_LOCATOR, $node->getParentName()) === 1;
     }
 }

--- a/src/Project/Common/ProjectNoBridgeRule.php
+++ b/src/Project/Common/ProjectNoBridgeRule.php
@@ -19,6 +19,11 @@ class ProjectNoBridgeRule extends AbstractRule implements ClassAware
     public const RULE = 'Project should not use and depend on Bridge pattern.';
 
     /**
+     * @var string
+     */
+    public const REGEX_BRIDGE = '/\w+Bridge$/';
+
+    /**
      * @return string
      */
     public function getDescription(): string
@@ -33,28 +38,61 @@ class ProjectNoBridgeRule extends AbstractRule implements ClassAware
      */
     public function apply(AbstractNode $node): void
     {
-        if (preg_match('([\w]+Bridge$)', $node->getFullQualifiedName()) !== 0) {
-            $this->addViolation(
-                $node,
-                [
-                    sprintf('Project should not use bridges: %s.', $node->getFullQualifiedName()),
-                ],
-            );
+        $this->applyNotUseBridge($node);
+        $this->applyNotDependOnBridges($node);
+    }
+
+    /**
+     * @param \PHPMD\AbstractRule $node
+     *
+     * @return void
+     */
+    protected function applyNotUseBridge(AbstractNode $node): void
+    {
+        if (!$this->isBridge($node->getFullQualifiedName())) {
+            return;
         }
 
+        $this->addViolation(
+            $node,
+            [
+                sprintf('Project should not use bridges: %s.', $node->getFullQualifiedName()),
+            ],
+        );
+    }
+
+    /**
+     * @param \PHPMD\AbstractNode $node
+     *
+     * @return void
+     */
+    protected function applyNotDependOnBridges(AbstractNode $node): void
+    {
         foreach ($node->getMethods() as $method) {
             foreach ($method->getDependencies() as $dependency) {
                 $targetQName = sprintf('%s\\%s', $dependency->getNamespaceName(), $dependency->getName());
 
-                if (preg_match('([\w]+Bridge$)', $targetQName) !== 0) {
-                    $this->addViolation(
-                        $method,
-                        [
-                            sprintf('Project should not depend on bridges: %s.', $targetQName),
-                        ],
-                    );
+                if (!$this->isBridge($targetQName)) {
+                    continue;
                 }
+
+                $this->addViolation(
+                    $method,
+                    [
+                        sprintf('Project should not depend on bridges: %s.', $targetQName),
+                    ],
+                );
             }
         }
+    }
+
+    /**
+     * @param string $nodeName
+     *
+     * @return bool
+     */
+    protected function isBridge(string $nodeName): bool
+    {
+        return preg_match(static::REGEX_BRIDGE, $nodeName) === 1;
     }
 }

--- a/src/Project/Common/SingletonInstanceInDependencyProviderOnlyRule.php
+++ b/src/Project/Common/SingletonInstanceInDependencyProviderOnlyRule.php
@@ -75,11 +75,7 @@ class SingletonInstanceInDependencyProviderOnlyRule extends AbstractRule impleme
         $parent = $node->getNode()->getParent();
         $className = $parent->getNamespaceName() . '\\' . $parent->getName();
 
-        if (preg_match('/\\\\' . '(?:Client|Yves|Glue|Zed|Service)' . '\\\\.*\\\\\w+DependencyProvider$/', $className)) {
-            return true;
-        }
-
-        return false;
+        return preg_match('/\\\\' . '(?:Client|Yves|Glue|Zed|Service)' . '\\\\.*\\\\\w+DependencyProvider$/', $className) === 1;
     }
 
     /**
@@ -89,11 +85,7 @@ class SingletonInstanceInDependencyProviderOnlyRule extends AbstractRule impleme
      */
     protected function isGetInstance(string $methodName): bool
     {
-        if (preg_match(static::GET_INSTANCE_METHOD_NAME, $methodName)) {
-            return true;
-        }
-
-        return false;
+        return preg_match(static::GET_INSTANCE_METHOD_NAME, $methodName) === 1;
     }
 
     /**
@@ -103,10 +95,6 @@ class SingletonInstanceInDependencyProviderOnlyRule extends AbstractRule impleme
      */
     protected function isStaticCall(string $callSymbol): bool
     {
-        if (preg_match('::', $callSymbol)) {
-            return true;
-        }
-
-        return false;
+        return preg_match('::', $callSymbol) === 1;
     }
 }

--- a/src/Project/Common/WeirdModuleNameRule.php
+++ b/src/Project/Common/WeirdModuleNameRule.php
@@ -29,7 +29,7 @@ class WeirdModuleNameRule extends AbstractRule implements ClassAware
     /**
      * @var string
      */
-    protected const WEIRD_MODULE_NAME_PATTER = '(^[\w]+\\\\(Zed|Client|Yves|Glue|Service|Shared)\\\\[\w]*(?i:test|dummy|example|antelope)[\w]*\\\\.+)';
+    protected const WEIRD_MODULE_NAME_PATTERN = '/^[\w]+\\\\(Zed|Client|Yves|Glue|Service|Shared)\\\\[\w]*(?i:test|dummy|example|antelope)[\w]*\\\\.+/';
 
     /**
      * @param \PHPMD\AbstractNode $node
@@ -40,7 +40,7 @@ class WeirdModuleNameRule extends AbstractRule implements ClassAware
     {
         $classFullName = $node->getFullQualifiedName();
 
-        if (preg_match(static::WEIRD_MODULE_NAME_PATTER, $classFullName) === 0) {
+        if (!$this->isWeirdClassName($classFullName)) {
             return;
         }
 
@@ -50,5 +50,15 @@ class WeirdModuleNameRule extends AbstractRule implements ClassAware
                 sprintf('Module name %s should not contain weird words: test|dummy|example|antelope.', $classFullName),
             ],
         );
+    }
+
+    /**
+     * @param string $classFullName
+     *
+     * @return bool
+     */
+    protected function isWeirdClassName(string $classFullName): bool
+    {
+        return preg_match(static::WEIRD_MODULE_NAME_PATTERN, $classFullName) === 1;
     }
 }


### PR DESCRIPTION
## PR Description
This commit simplifies the PHPMD (PHP Mess Detector) rules logic, improving overall code readability and maintainability. In several classes, unnecessary if-else checks were converted into more straightforward return statements. In addition, helper methods were introduced to reduce code duplication. This results in cleaner and more concise code that is easier to understand and modify in the future.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
